### PR TITLE
Allow discovering package name in the toop level of the project directory

### DIFF
--- a/src/kedro_init/modules.py
+++ b/src/kedro_init/modules.py
@@ -17,9 +17,9 @@ def get_or_create_modules(
         module_templates = MODULE_TEMPLATES
 
     package_name = build_config["package_name"]
-    package_dir = next(project_root.glob(f"*/{package_name}"), None)
-    if package_dir is None:
-        package_dir = next(project_root.glob(f"{package_name}"), None)
+    package_dir = project_root / package_name
+    if not package_dir.is_dir():
+        package_dir = next(project_root.glob(f"*/{package_name}"), None)
 
     modules = {}
     for module_name in module_templates:

--- a/src/kedro_init/modules.py
+++ b/src/kedro_init/modules.py
@@ -18,6 +18,8 @@ def get_or_create_modules(
 
     package_name = build_config["package_name"]
     package_dir = next(project_root.glob(f"*/{package_name}"), None)
+    if package_dir is None:
+        package_dir = next(project_root.glob(f"{package_name}"), None)
 
     modules = {}
     for module_name in module_templates:


### PR DESCRIPTION
Kedro init expects to find the package in a subdirectory of the project root. If the package is in the top level, it fails. This PR fixes the issue.

<!-- readthedocs-preview kedro-init start -->
----
📚 Documentation preview 📚: https://kedro-init--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview kedro-init end -->